### PR TITLE
First Pass at different tracks for each type

### DIFF
--- a/src/services/LegenedService.js
+++ b/src/services/LegenedService.js
@@ -24,10 +24,10 @@ export function createLegendBox() {
     returnString += `</tr>`;
     returnString += `<tr>`;
     returnString += `<td valign="top" ><ul style="list-style-type:none;">`;
-    returnString += `<li><svg width="15" top="3" viewBox="-7 -2 15 15" style="display: inline;" xmlns="http://www.w3.org/2000/svg"><polygon stroke="black" fill="black" points="${generateSnvPoints(0)}"></svg>point mutation / MNV </polygons></svg></li>`;
+    returnString += `<li><svg width="15" top="3" viewBox="-7 -2 15 15" style="display: inline;" xmlns="http://www.w3.org/2000/svg"><polygon stroke="black" fill="black" points="${generateSnvPoints(0)}"></svg>point mutation</polygons></svg></li>`;
     returnString += `<li>${drawDeletion('black','deletion')}</li>`;
     returnString += `<li><svg width="15" top="3" viewBox="-7 -2 15 15" style="display: inline;" xmlns="http://www.w3.org/2000/svg"><polygon stroke="black" fill="black" points="${generateInsertionPoint(0)}"></svg>insertion</polygons></svg></li>`;
-    returnString += `<li><svg width="15" top="3" viewBox="-7 -2 15 15" style="display: inline;" xmlns="http://www.w3.org/2000/svg"><polygon stroke="black" fill="black" points="${generateDelinsPoint(0)}"></svg>delins </polygons></svg></li>`;
+    returnString += `<li><svg width="15" top="3" viewBox="-7 -2 15 15" style="display: inline;" xmlns="http://www.w3.org/2000/svg"><polygon stroke="black" fill="black" points="${generateDelinsPoint(0)}"></svg>delins/MNV </polygons></svg></li>`;
     returnString += `</ul></td>`;
     returnString += `<td valign="top" ><ul style="list-style-type:none;">`;
     returnString += `<li>${drawDeletionForConsequence('transcript_ablation')}</li>`;

--- a/src/services/VariantService.js
+++ b/src/services/VariantService.js
@@ -34,8 +34,8 @@ function findVariantBinIndexForPosition(variantBins,variant,buffer) {
     const relativeMin = fb.fmin + buffer;
     const relativeMax = fb.fmax - buffer;
 
-    // they can share type so long as neither is a deletion
-    if( (type==='deletion' || fb.type ==='deletion') && type !== fb.type ) return false ;
+    // They cannot share a bin if they are different types.
+    if( type !== fb.type ) return false ;
 
     // if we overlap thAe min edge then take the minimum and whatever the maximum and add
     if(relativeMin <= fmin && relativeMax >= fmin){
@@ -396,4 +396,24 @@ export function getVariantSymbol(variant){
   // return  (symbol.length>20 ? symbol.substr(0,20) : symbol).replace(/"/g,"");
   symbol = symbol.replace (/<sup>/," ");
   return symbol.replace(/"|<\/sup>/g,"");
+}
+
+export function getVariantTrackPositions(variantData){
+  let presentVariants=[];
+  for (var variant of variantData){
+    if (variant.type.toLowerCase() === 'deletion') {
+      presentVariants.push('deletion');
+    }
+    else if (variant.type.toLowerCase() === 'snv' || variant.type.toLowerCase() === 'point_mutation') {
+      presentVariants.push('snv');
+    }
+    else if (variant.type.toLowerCase() === 'insertion') {
+      presentVariants.push('insertion');
+    }
+    else if (variant.type.toLowerCase() === 'delins' || variant.type.toLowerCase() === 'substitution' || variant.type.toLowerCase() === 'indel' || variant.type.toLowerCase() === 'mnv') {
+      presentVariants.push('delins');
+    }
+  }
+  let distinctVariants = [...new Set(presentVariants)];
+  return distinctVariants.sort();
 }

--- a/src/tracks/IsoformAndVariantTrack.js
+++ b/src/tracks/IsoformAndVariantTrack.js
@@ -9,6 +9,7 @@ import {
   getVariantDescriptions,
   getVariantSymbol,
   renderVariantDescriptions,
+  getVariantTrackPositions,
 } from "../services/VariantService";
 import {renderTrackDescription} from "../services/TrackService";
 // import {description} from "d3/dist/package";
@@ -43,6 +44,9 @@ export default class IsoformAndVariantTrack {
     let width = this.width;
     let showVariantLabel = this.showVariantLabel;
     let binRatio = this.binRatio;
+
+    let distinctVariants= getVariantTrackPositions(variantData);
+    let numVariantTracks=distinctVariants.length;
 
 
     let UTR_feats = ["UTR", "five_prime_UTR", "three_prime_UTR"];
@@ -89,7 +93,7 @@ export default class IsoformAndVariantTrack {
     let variantContainer = viewer.append("g").attr("class", "variants track")
       .attr("transform", "translate(0,22.5)");
     //Append Invisible Rect to give space properly if only one track exists.
-    variantContainer.append('rect').style("opacity", 0).attr("height", VARIANT_TRACK_HEIGHT).attr("width",width);
+    //variantContainer.append('rect').style("opacity", 0).attr("height", VARIANT_HEIGHT*numVariantTracks).attr("width",width);
 
     //need to build a new sortWeight since these can be dynamic
     let sortWeight = {};
@@ -138,11 +142,11 @@ export default class IsoformAndVariantTrack {
         let descriptionHtml = renderVariantDescriptions(descriptions);
         const consequenceColor = getColorsForConsequences(descriptions)[0];
         const width = Math.ceil(x(fmax)-x(fmin)) < MIN_WIDTH ? MIN_WIDTH : Math.ceil(x(fmax)-x(fmin));
-        if (type.toLowerCase() === 'deletion' || type.toLowerCase() === 'mnv') {
+        if (type.toLowerCase() === 'deletion') {
           variantContainer.append('rect')
             .attr('class', 'variant-deletion')
             .attr('x', x(fmin))
-            .attr('transform', 'translate(0,0)')
+            .attr('transform', 'translate(0,'+VARIANT_HEIGHT*distinctVariants.indexOf("deletion")+')')
             .attr('z-index', 30)
             .attr('fill', consequenceColor)
             .attr('height', VARIANT_HEIGHT)
@@ -173,7 +177,7 @@ export default class IsoformAndVariantTrack {
             .attr('points', generateSnvPoints(x(fmin)))
             .attr('fill', consequenceColor)
             .attr('x', x(fmin))
-            .attr('transform', 'translate(0,'+VARIANT_HEIGHT+')')
+            .attr('transform', 'translate(0,'+VARIANT_HEIGHT*distinctVariants.indexOf("snv")+')')
             .attr('z-index', 30)
             .on("click", d => {
               renderTooltipDescription(tooltipDiv,descriptionHtml,closeToolTip);
@@ -201,7 +205,7 @@ export default class IsoformAndVariantTrack {
               .attr('points', generateInsertionPoint(x(fmin)))
               .attr('fill', consequenceColor)
               .attr('x', x(fmin))
-              .attr('transform', 'translate(0,'+VARIANT_HEIGHT+')')
+              .attr('transform', 'translate(0,'+VARIANT_HEIGHT*distinctVariants.indexOf("insertion")+')')
               .attr('z-index', 30)
               .on("click", d => {
                 renderTooltipDescription(tooltipDiv,descriptionHtml,closeToolTip);
@@ -222,13 +226,13 @@ export default class IsoformAndVariantTrack {
                   .style("opacity",0);
               })
               .datum({fmin: fmin, fmax: fmax, variant: symbol_string+fmin});
-        } else if (type.toLowerCase() === 'delins' || type.toLowerCase() === 'substitution' || type.toLowerCase() === 'indel') {
+        } else if (type.toLowerCase() === 'delins' || type.toLowerCase() === 'substitution' || type.toLowerCase() === 'indel' || type.toLowerCase() === 'mnv') {
           isPoints=true;
           variantContainer.append('polygon')
             .attr('class', 'variant-delins')
             .attr('points', generateDelinsPoint(x(fmin)))
             .attr('x', x(fmin))
-            .attr('transform', 'translate(0,0)')
+            .attr('transform', 'translate(0,'+VARIANT_HEIGHT*distinctVariants.indexOf("delins")+')')
             .attr('fill', consequenceColor)
             .attr('z-index', 30)
             .on("click", d => {
@@ -264,13 +268,13 @@ export default class IsoformAndVariantTrack {
             label_offset = x(fmin);}
 
           const symbol_string_length = symbol_string.length ? symbol_string.length : 1;
-
+          let label_height=VARIANT_HEIGHT*numVariantTracks+15;
           let variant_label = variantContainer.append('text')
             .attr('class', 'variantLabel')
             .attr('fill', consequenceColor)
             .attr('opacity', 0)
             .attr('height', ISOFORM_TITLE_HEIGHT)
-            .attr("transform", "translate("+label_offset+",45)")
+            .attr("transform", "translate("+label_offset+","+label_height+")")
             .html(symbol_string)
             .on("click", d => {
               renderTooltipDescription(tooltipDiv,descriptionHtml,closeToolTip);

--- a/src/tracks/IsoformAndVariantTrack.js
+++ b/src/tracks/IsoformAndVariantTrack.js
@@ -75,6 +75,7 @@ export default class IsoformAndVariantTrack {
     const SNV_HEIGHT = 10;
     const SNV_WIDTH = 10;
     const VARIANT_TRACK_HEIGHT = 40;//Not sure if this needs to be dynamic or not
+    const LABEL_PADDING=22.5;
 
     const insertion_points = (x) => {
       return `${x-(SNV_WIDTH/2.0)},${SNV_HEIGHT} ${x},0 ${x+(SNV_WIDTH/2.0)},${SNV_HEIGHT}`;
@@ -268,7 +269,7 @@ export default class IsoformAndVariantTrack {
             label_offset = x(fmin);}
 
           const symbol_string_length = symbol_string.length ? symbol_string.length : 1;
-          let label_height=VARIANT_HEIGHT*numVariantTracks+15;
+          let label_height=VARIANT_HEIGHT*numVariantTracks+LABEL_PADDING;
           let variant_label = variantContainer.append('text')
             .attr('class', 'variantLabel')
             .attr('fill', consequenceColor)


### PR DESCRIPTION
In this commit now each of the categories of type (those that have a 
symbol) now get allocated a track.  They are also binned by type so features of different types never bin together.  Also if not all types are present the space is not allocated for them.