### PR TITLE
Agr 2367

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agr_genomefeaturecomponent",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Provides SVG View for Genome Features rendered with the Apollo Track Web Service via JBrowse",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/tracks/IsoformTrack.js
+++ b/src/tracks/IsoformTrack.js
@@ -59,6 +59,7 @@ export default class IsoformTrack {
 
         let view_start = this.start;
         let view_end = this.end;
+        let viewerWidth = this.width;
         let exon_height = 10; // will be white / transparent
         let cds_height = 10; // will be colored in
         let isoform_height = 40; // height for each isoform
@@ -136,11 +137,6 @@ export default class IsoformTrack {
 
                 // For each isoform..
                 featureChildren.forEach(function (featureChild) {
-                    //skip feats not within bounds.
-                    if(featureChild.fmin<view_start || featureChild.fmax>view_end){
-                      console.log(featureChild.fmax, view_start);
-                      return;
-                    }
                     let featureType = featureChild.type;
 
                     if (display_feats.indexOf(featureType) >= 0) {
@@ -152,18 +148,20 @@ export default class IsoformTrack {
                             let isoform = track.append("g").attr("class", "isoform")
                                 .attr("transform", "translate(0," + ((row_count * isoform_height) + 10) + ")");
 
+                            let transcript_start= x(featureChild.fmin) > 0 ? x(featureChild.fmin) : 0;
+                            let transcript_end = x(featureChild.fmax) > viewerWidth ? viewerWidth : x(featureChild.fmax);
                             isoform.append("polygon")
                                 .datum(function () {
-                                    return {fmin: featureChild.fmin, fmax: featureChild.fmax, strand: feature.strand};
+                                    return {strand: feature.strand};
                                 })
                                 .attr('class', 'transArrow')
                                 .attr('points', arrow_points)
                                 .attr('transform', function (d) {
                                     if (feature.strand > 0) {
-                                        return 'translate(' + Number(x(d.fmax)) + ',0)';
+                                        return 'translate(' + transcript_end + ',0)';
                                     }
                                     else {
-                                        return 'translate(' + Number(x(d.fmin)) + ','+arrow_height+') rotate(180)';
+                                        return 'translate(' + transcript_start + ','+arrow_height+') rotate(180)';
                                     }
                                 })
                               .on("click", d => {
@@ -175,8 +173,8 @@ export default class IsoformTrack {
                                 .attr('class', 'transcriptBackbone')
                                 .attr('y', 10 + isoform_title_height)
                                 .attr('height', transcript_backbone_height)
-                                .attr("transform", "translate(" + x(featureChild.fmin) + ",0)")
-                                .attr('width', x(featureChild.fmax) - x(featureChild.fmin))
+                                .attr("transform", "translate(" + transcript_start + ",0)")
+                                .attr('width', transcript_end - transcript_start)
                                 .datum({fmin: featureChild.fmin, fmax: featureChild.fmax})
                               .on("click", d => {
                                 renderTooltipDescription(tooltipDiv,renderTrackDescription(featureChild),closeToolTip);
@@ -186,18 +184,26 @@ export default class IsoformTrack {
                             if(feature.name !== featureChild.name){
                               text_string +=  " (" + feature.name + ")";
                             }
+                            let label_offset = x(featureChild.fmin) > 0 ? x(featureChild.fmin) : 0;
                             let text_label = isoform.append('text')
                                 .attr('class', 'transcriptLabel')
                                 .attr('fill', selected ? 'sandybrown' : 'gray')
                                 .attr('opacity', selected ? 1 : 0.5)
                                 .attr('height', isoform_title_height)
-                                .attr("transform", "translate(" + x(featureChild.fmin) + ",0)")
+                                .attr("transform", "translate(" + label_offset+ ",0)")
                                 .text(text_string)
                                 .datum({fmin: featureChild.fmin})
                               .on("click", d => {
                                 renderTooltipDescription(tooltipDiv,renderTrackDescription(featureChild),closeToolTip);
-                              })
-                            ;
+                              });
+
+                              let symbol_string_width = text_label.node().getBBox().width;
+                              if(parseFloat(symbol_string_width+label_offset)>viewerWidth){
+                                let diff = parseFloat(symbol_string_width+label_offset-viewerWidth);
+                                console.log(diff,viewerWidth,symbol_string_width);
+                                label_offset-=diff;
+                                text_label.attr("transform", "translate("+label_offset+",0)");
+                              }
 
                             //Now that the label has been created we can calculate the space that
                             //this new element is taking up making sure to add in the width of
@@ -268,14 +274,20 @@ export default class IsoformTrack {
 
                               featureChild.children.forEach(function (innerChild) {
                                 let innerType = innerChild.type;
+                                //Skip feats out of bounds.
+                                if(x(innerChild.fmin)>viewerWidth || x(innerChild.fmax)<0){
+                                  return;//skip feat
+                                }
+                                let inner_start= x(innerChild.fmin) > 0 ? x(innerChild.fmin) : 0;
+                                let inner_end = x(innerChild.fmax) > viewerWidth ? viewerWidth : x(innerChild.fmax);
                                 if (exon_feats.indexOf(innerType) >= 0) {
                                     isoform.append('rect')
                                         .attr('class', 'exon')
-                                        .attr('x', x(innerChild.fmin))
+                                        .attr('x', inner_start)
                                         .attr('transform', 'translate(0,' + (exon_height - transcript_backbone_height) + ')')
                                         .attr('height', exon_height)
                                         .attr('z-index', 10)
-                                        .attr('width', x(innerChild.fmax) - x(innerChild.fmin))
+                                        .attr('width', inner_end - inner_start)
                                         .datum({fmin: innerChild.fmin, fmax: innerChild.fmax})
                                         .on("click", d => {
                                             renderTooltipDescription(tooltipDiv,renderTrackDescription(featureChild),closeToolTip);
@@ -284,11 +296,11 @@ export default class IsoformTrack {
                                 else if (CDS_feats.indexOf(innerType) >= 0) {
                                     isoform.append('rect')
                                         .attr('class', 'CDS')
-                                        .attr('x', x(innerChild.fmin))
+                                        .attr('x', inner_start)
                                         .attr('transform', 'translate(0,' + (cds_height - transcript_backbone_height) + ')')
                                         .attr('z-index', 20)
                                         .attr('height', cds_height)
-                                        .attr('width', x(innerChild.fmax) - x(innerChild.fmin))
+                                        .attr('width', inner_end - inner_start)
                                         .datum({fmin: innerChild.fmin, fmax: innerChild.fmax})
                                         .on("click", d => {
                                             renderTooltipDescription(tooltipDiv,renderTrackDescription(featureChild),closeToolTip);
@@ -297,11 +309,11 @@ export default class IsoformTrack {
                                 else if (UTR_feats.indexOf(innerType) >= 0) {
                                     isoform.append('rect')
                                         .attr('class', 'UTR')
-                                        .attr('x', x(innerChild.fmin))
+                                        .attr('x', inner_start)
                                         .attr('transform', 'translate(0,' + (utr_height - transcript_backbone_height) + ')')
                                         .attr('z-index', 20)
                                         .attr('height', utr_height)
-                                        .attr('width', x(innerChild.fmax) - x(innerChild.fmin))
+                                        .attr('width', inner_end - inner_start)
                                         .datum({fmin: innerChild.fmin, fmax: innerChild.fmax})
                                         .on("click", d => {
                                           renderTooltipDescription(tooltipDiv,renderTrackDescription(featureChild),closeToolTip);

--- a/src/tracks/IsoformTrack.js
+++ b/src/tracks/IsoformTrack.js
@@ -11,6 +11,8 @@ export default class IsoformTrack {
         this.width = width;
         this.height = height;
         this.transcriptTypes = transcriptTypes;
+        this.start = track["start"];
+        this.end = track["end"];
     }
 
   renderTooltipDescription(tooltipDiv, descriptionHtml,closeFunction){
@@ -55,8 +57,8 @@ export default class IsoformTrack {
         let display_feats = this.transcriptTypes;
         let dataRange = findRange(data, display_feats);
 
-        let view_start = dataRange.fmin;
-        let view_end = dataRange.fmax;
+        let view_start = this.start;
+        let view_end = this.end;
         let exon_height = 10; // will be white / transparent
         let cds_height = 10; // will be colored in
         let isoform_height = 40; // height for each isoform
@@ -131,9 +133,14 @@ export default class IsoformTrack {
                     return a - b;
                 });
 
+
                 // For each isoform..
                 featureChildren.forEach(function (featureChild) {
-                    //
+                    //skip feats not within bounds.
+                    if(featureChild.fmin<view_start || featureChild.fmax>view_end){
+                      console.log(featureChild.fmax, view_start);
+                      return;
+                    }
                     let featureType = featureChild.type;
 
                     if (display_feats.indexOf(featureType) >= 0) {


### PR DESCRIPTION
Fixing AGR 2367 and  some of 2342.

This pull will center the view around the requested region and display partial features.  This will also now correctly display the axis values.  Included in this is a correction to transcript labels.  

A couple of notes on the fix here thus far.   The code will display any part of a feature that is returned within the data range.  Right now it simply cuts off the rest of the feature.  It will also move the transcript arrows if necessary though these are rendered slightly "out of bounds" within the browser.  Also, if a transcript label would render beyond the bounds of the browser it will recenter it within those bounds.  On the right side of the browser this is done via the bbox method since its hard to determine how long a box is without actually rendering it.  Last note this only applies to the isoform track rendering.  Everything here could be moved to the isoform and variant track fairly easily once finalized.

I'm not sure if this is ready for merge... any comments Nathan would be appreciated.