### PR TITLE
The ID for mouse is in the name field in the apollo return.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agr_genomefeaturecomponent",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Provides SVG View for Genome Features rendered with the Apollo Track Web Service via JBrowse",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/demo/index.js
+++ b/src/demo/index.js
@@ -29,7 +29,7 @@ function covidExamples(){
 
 function currentExamples(){
   createExample("X:2023822..2042311", "fly", "viewerActnFly", TRACK_TYPE.ISOFORM_AND_VARIANT, false,["FB:FBal0212726"],['FBtr0070344','FBtr0070346']);
-  createExample("8:57320983..57324517", "mouse", "viewerHand2Mouse", TRACK_TYPE.ISOFORM_AND_VARIANT, false);
+  createExample("8:57320983..57324517", "mouse", "viewerHand2Mouse", TRACK_TYPE.ISOFORM_AND_VARIANT, false,[],['ENSMUST00000185635']);
   createExample("6:18170687..18322768", "mouse", "viewerCftrMouse", TRACK_TYPE.ISOFORM_AND_VARIANT, false);
   createCoVExample("NC_045512.2:17894..28259", "SARS-CoV-2", "covidExample1", TRACK_TYPE.ISOFORM, false);
 }

--- a/src/tracks/IsoformAndVariantTrack.js
+++ b/src/tracks/IsoformAndVariantTrack.js
@@ -373,7 +373,7 @@ export default class IsoformAndVariantTrack {
         // For each isoform..
         let warningRendered = false ;
         featureChildren.forEach(function (featureChild) {
-          if(!(isoformFilter.indexOf(featureChild.id) >= 0) && isoformFilter.length!==0){
+          if(!(isoformFilter.indexOf(featureChild.id) >= 0 || isoformFilter.indexOf(featureChild.name) >= 0 ) && isoformFilter.length!==0){
             return;
           }
           //


### PR DESCRIPTION
The return for apollo and the return for the API dont have the same ID field in mouse.  We might need to look at that for a future release but for now this fixes the filtering on the allele page.  Will bump version and push to agr_ui if you've got no issues.